### PR TITLE
Add options to prevent Verdin from adding a variable or function fragment to the completion list

### DIFF
--- a/autoload/Verdin.vim
+++ b/autoload/Verdin.vim
@@ -32,6 +32,9 @@ let g:Verdin#setomnifunc       =  get(g:, 'Verdin#setomnifunc',
 let g:Verdin#autoparen         = get(g:, 'Verdin#autoparen',
                                \ get(g:, 'Verdin#autobraketinsert',
                                \     s:default.autoparen))
+
+let g:Verdin#disable_var_fragment = get(g:, 'Verdin#disable_var_fragment', 0)
+let g:Verdin#disable_func_fragment = get(g:, 'Verdin#disable_func_fragment', 0)
 "}}}
 
 " The omni-completion function for Vim script

--- a/autoload/Verdin/Observer.vim
+++ b/autoload/Verdin/Observer.vim
@@ -397,15 +397,19 @@ function! s:inspectvim(...) dict abort "{{{
     let augroup = Verdin#Dictionary#new('augroup', s:const.AUGROUPCONDITIONLIST, augrouplist, 1)
     call s:inject(self.shelf['bufferaugroup'], augroup)
   endif
-  if self.shelf.funcfragment == {}
-    let funcfragmentwordlist = s:funcfragmentwordlist(self.bufnr)
-    let funcfragment = Verdin#Dictionary#new('funcfragment', s:const.FUNCFRAGMENTCONDITIONLIST, funcfragmentwordlist)
-    call s:inject(self.shelf['funcfragment'], funcfragment)
+  if !g:Verdin#disable_func_fragment
+    if self.shelf.funcfragment == {}
+      let funcfragmentwordlist = s:funcfragmentwordlist(self.bufnr)
+      let funcfragment = Verdin#Dictionary#new('funcfragment', s:const.FUNCFRAGMENTCONDITIONLIST, funcfragmentwordlist)
+      call s:inject(self.shelf['funcfragment'], funcfragment)
+    endif
   endif
-  let varfragmentwordlist = s:varfragmentwordlist(varlist)
-  if varfragmentwordlist != []
-    let varfragment = Verdin#Dictionary#new('varfragment', s:const.VARFRAGMENTCONDITIONLIST, varfragmentwordlist)
-    call s:inject(self.shelf['varfragment'], varfragment)
+  if !g:Verdin#disable_var_fragment
+    let varfragmentwordlist = s:varfragmentwordlist(varlist)
+    if varfragmentwordlist != []
+      let varfragment = Verdin#Dictionary#new('varfragment', s:const.VARFRAGMENTCONDITIONLIST, varfragmentwordlist)
+      call s:inject(self.shelf['varfragment'], varfragment)
+    endif
   endif
   call clock.stop()
 endfunction "}}}

--- a/doc/Verdin.txt
+++ b/doc/Verdin.txt
@@ -113,6 +113,23 @@ after a completed function name.
 `b:Verdin_autoparen` works buffer-locally prior to
 |g:Verdin#autoparen|.
 
+------------------------------------------------------------------------------
+
+					*g:Verdin#disable_var_fragment*
+To prevent Verdin from adding the variable fragment to the completion list:
+>
+	let g:Verdin#disable_var_fragment = 1
+<
+------------------------------------------------------------------------------
+
+					*g:Verdin#disable_func_fragment*
+To prevent Verdin from adding the function fragment to the completion list:
+>
+	let g:Verdin#disable_func_fragment = 1
+<
+
+------------------------------------------------------------------------------
+
 ==============================================================================
 COMMANDS				*Verdin-commands*
 


### PR DESCRIPTION
This pull request adds two options to Verdin:

1. _g:Verdin#disable_var_fragment_ to prevent Verdin from adding the variable fragment to the completion list:
```
let g:Verdin#disable_var_fragment = 1
```

3. _g:Verdin#disable_func_fragment_ to prevent Verdin from adding the function fragment to the completion list:
```
let g:Verdin#disable_func_fragment = 1
```
